### PR TITLE
feat: add meal planner with smart list integration

### DIFF
--- a/Fridge to Recipe/CollaborativeShoppingView.swift
+++ b/Fridge to Recipe/CollaborativeShoppingView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct CollaborativeShoppingView: View {
+    @EnvironmentObject var appData: AppDataModel
+    @EnvironmentObject var shoppingList: ShoppingListViewModel
     @StateObject private var collaborativeService = CollaborativeService()
     @State private var showAuthSheet = false
     @State private var showCreateList = false
@@ -62,6 +64,9 @@ struct CollaborativeShoppingView: View {
         }
         .sheet(isPresented: $showAccountSheet) {
             AccountManagementView(collaborativeService: collaborativeService)
+        }
+        .onAppear {
+            shoppingList.updateSmartList(from: appData.mealPlans, recipes: appData.recipes)
         }
     }
     

--- a/Fridge to Recipe/MainTabView.swift
+++ b/Fridge to Recipe/MainTabView.swift
@@ -32,13 +32,21 @@ struct MainTabView: View {
                 }
                 .tag(2)
                 .environmentObject(appData)
-            
+
+            MealPlannerView()
+                .tabItem {
+                    Image(systemName: "calendar")
+                    Text("Planner")
+                }
+                .tag(3)
+                .environmentObject(appData)
+
             CollaborativeShoppingView()
                 .tabItem {
                     Image(systemName: "person.2.fill")
                     Text("Collaborate")
                 }
-                .tag(3)
+                .tag(4)
                 .environmentObject(appData)
         }
         .accentColor(.blue)

--- a/Fridge to Recipe/MealPlannerView.swift
+++ b/Fridge to Recipe/MealPlannerView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+struct MealPlannerView: View {
+    @EnvironmentObject var appData: AppDataModel
+    @EnvironmentObject var shoppingList: ShoppingListViewModel
+    @State private var currentDate = Date()
+
+    var body: some View {
+        VStack {
+            Text("Meal Planner")
+                .font(.largeTitle.weight(.bold))
+                .padding()
+
+            CalendarGrid(currentDate: $currentDate, mealPlans: $appData.mealPlans) { recipeID, date in
+                appData.addRecipe(recipeID, to: date)
+                shoppingList.updateSmartList(from: appData.mealPlans, recipes: appData.recipes)
+            }
+            .padding()
+
+            Text("Recipes")
+                .font(.headline)
+                .padding(.top)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack {
+                    ForEach(appData.recipes) { recipe in
+                        Text(recipe.name)
+                            .padding(8)
+                            .background(Color.blue.opacity(0.2))
+                            .cornerRadius(8)
+                            .onDrag {
+                                NSItemProvider(object: recipe.id.uuidString as NSString)
+                            }
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+}
+
+struct CalendarGrid: View {
+    @Binding var currentDate: Date
+    @Binding var mealPlans: [MealPlan]
+    var onAdd: (UUID, Date) -> Void
+
+    var body: some View {
+        let days = generateDays(for: currentDate)
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 7), spacing: 8) {
+            ForEach(days, id: \\.self) { date in
+                DayCell(date: date,
+                        recipes: mealPlans.first { Calendar.current.isDate($0.date, inSameDayAs: date) }?.recipeIDs ?? [],
+                        onAdd: { id in onAdd(id, date) })
+            }
+        }
+    }
+
+    private func generateDays(for date: Date) -> [Date] {
+        let calendar = Calendar.current
+        guard let monthRange = calendar.range(of: .day, in: .month, for: date) else { return [] }
+        var days: [Date] = []
+        let components = calendar.dateComponents([.year, .month], from: date)
+        for day in monthRange {
+            var dayComponents = components
+            dayComponents.day = day
+            if let dayDate = calendar.date(from: dayComponents) {
+                days.append(dayDate)
+            }
+        }
+        return days
+    }
+}
+
+struct DayCell: View {
+    let date: Date
+    let recipes: [UUID]
+    var onAdd: (UUID) -> Void
+    @EnvironmentObject var appData: AppDataModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("\(Calendar.current.component(.day, from: date))")
+                .font(.subheadline.bold())
+            ForEach(recipes, id: \\.self) { id in
+                if let recipe = appData.recipes.first(where: { $0.id == id }) {
+                    Text(recipe.name)
+                        .font(.caption)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .padding(4)
+        .frame(minHeight: 60)
+        .background(Color.white.opacity(0.8))
+        .cornerRadius(8)
+        .onDrop(of: ["public.text"], isTargeted: nil) { providers in
+            guard let provider = providers.first else { return false }
+            provider.loadObject(ofClass: NSString.self) { item, _ in
+                if let str = item as? String, let id = UUID(uuidString: str) {
+                    DispatchQueue.main.async {
+                        onAdd(id)
+                    }
+                }
+            }
+            return true
+        }
+    }
+}
+

--- a/Fridge to Recipe/Models.swift
+++ b/Fridge to Recipe/Models.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import UserNotifications
 import Vision
 import VisionKit
+import FirebaseFirestore
 
 // MARK: - Models
 struct IngredientEntry: Identifiable, Equatable, Codable {
@@ -98,6 +99,18 @@ struct RecipeMatch: Identifiable, Equatable {
     let isExact: Bool
 }
 
+struct MealPlan: Identifiable, Codable, Equatable {
+    let id: String
+    var date: Date
+    var recipeIDs: [UUID]
+
+    init(id: String = UUID().uuidString, date: Date, recipeIDs: [UUID] = []) {
+        self.id = id
+        self.date = date
+        self.recipeIDs = recipeIDs
+    }
+}
+
 struct ShoppingListItem: Identifiable, Codable, Equatable {
     let id: UUID
     var name: String
@@ -127,6 +140,11 @@ class AppDataModel: ObservableObject {
     @Published var favouriteRecipeIDs: [UUID] = [] {
         didSet { saveFavourites() }
     }
+    @Published var mealPlans: [MealPlan] = [] {
+        didSet { saveMealPlans() }
+    }
+
+    private let db = Firestore.firestore()
 
     init() {
         // Load ingredients
@@ -139,6 +157,12 @@ class AppDataModel: ObservableObject {
            let saved = try? JSONDecoder().decode([UUID].self, from: data) {
             self.favouriteRecipeIDs = saved
         }
+        // Load meal plans
+        if let data = UserDefaults.standard.data(forKey: "mealPlans"),
+           let saved = try? JSONDecoder().decode([MealPlan].self, from: data) {
+            self.mealPlans = saved
+        }
+        loadMealPlansFromFirestore()
     }
     
     func scheduleExpiryNotification(for ingredient: IngredientEntry) {
@@ -157,6 +181,36 @@ class AppDataModel: ObservableObject {
     func cancelExpiryNotification(for ingredient: IngredientEntry) {
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["expiry-\(ingredient.id)"])
     }
+
+    func scheduleMealNotification(for plan: MealPlan) {
+        let content = UNMutableNotificationContent()
+        content.title = "Meal Reminder"
+        if let first = plan.recipeIDs.first,
+           let recipe = recipes.first(where: { $0.id == first }) {
+            content.body = "Don't forget: \(recipe.name) today!"
+        } else {
+            content.body = "You have meals planned today!"
+        }
+        content.sound = .default
+        let triggerDate = Calendar.current.dateComponents([.year, .month, .day], from: plan.date)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: false)
+        let request = UNNotificationRequest(identifier: "meal-\(plan.id)", content: content, trigger: trigger)
+        UNUserNotificationCenter.current().add(request)
+    }
+
+    func addRecipe(_ recipeID: UUID, to date: Date) {
+        if let index = mealPlans.firstIndex(where: { Calendar.current.isDate($0.date, inSameDayAs: date) }) {
+            if !mealPlans[index].recipeIDs.contains(recipeID) {
+                mealPlans[index].recipeIDs.append(recipeID)
+                persistMealPlan(mealPlans[index])
+            }
+        } else {
+            let plan = MealPlan(date: date, recipeIDs: [recipeID])
+            mealPlans.append(plan)
+            persistMealPlan(plan)
+            scheduleMealNotification(for: plan)
+        }
+    }
     
     private func saveIngredients() {
         // Save ingredients asynchronously to avoid blocking UI
@@ -167,6 +221,14 @@ class AppDataModel: ObservableObject {
             }
         }
     }
+    private func saveMealPlans() {
+        let plans = mealPlans
+        DispatchQueue.global(qos: .background).async {
+            if let data = try? JSONEncoder().encode(plans) {
+                UserDefaults.standard.set(data, forKey: "mealPlans")
+            }
+        }
+    }
     private func saveFavourites() {
         // Save favorites synchronously for immediate persistence and data reliability
         if let data = try? JSONEncoder().encode(favouriteRecipeIDs) {
@@ -174,6 +236,20 @@ class AppDataModel: ObservableObject {
             // Force synchronization to ensure data is written immediately
             UserDefaults.standard.synchronize()
         }
+    }
+
+    private func loadMealPlansFromFirestore() {
+        db.collection("mealPlans").addSnapshotListener { snapshot, _ in
+            guard let documents = snapshot?.documents else { return }
+            self.mealPlans = documents.compactMap {
+                try? Firestore.Decoder().decode(MealPlan.self, from: $0.data())
+            }
+        }
+    }
+
+    private func persistMealPlan(_ plan: MealPlan) {
+        guard let data = try? Firestore.Encoder().encode(plan) else { return }
+        db.collection("mealPlans").document(plan.id).setData(data)
     }
     
     // MARK: - Optimized Favorite Methods
@@ -279,7 +355,13 @@ class ShoppingListViewModel: ObservableObject {
             UserDefaults.standard.set(data, forKey: "manualLists")
         }
     }
-    
+
+    func updateSmartList(from mealPlans: [MealPlan], recipes: [Recipe]) {
+        let upcomingIDs = mealPlans.filter { $0.date >= Date() }.flatMap { $0.recipeIDs }
+        let upcomingRecipes = recipes.filter { upcomingIDs.contains($0.id) }
+        smartListItems = Array(Set(upcomingRecipes.flatMap { $0.ingredients }))
+    }
+
     // MARK: - Price Tracking Methods
     func getTotalPrice(for listName: String) -> Double {
         if listName == "Smart List" {


### PR DESCRIPTION
## Summary
- add MealPlan model and persistence with Firestore and notifications
- build MealPlannerView calendar and drag/drop recipes
- update Smart List from meal plans and expose planner tab

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a04c375b6c8330981c7684cdaf9140